### PR TITLE
Fixed type for MedImage Structure(struct) definition attributes within the MedImage_data_struct.jl

### DIFF
--- a/MedImage3D/.vscode/settings.json
+++ b/MedImage3D/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/hurtbadly/Desktop/julia_stuff/MedImage.jl/MedImage3D"
+}

--- a/MedImage3D/src/.vscode/settings.json
+++ b/MedImage3D/src/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/hurtbadly/Desktop/julia_stuff/MedImage.jl/MedImage3D/src"
+}

--- a/MedImage3D/src/Load_and_save.jl
+++ b/MedImage3D/src/Load_and_save.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(["DICOM","NIfTI","Dictionaries"])
+Pkg.add(["DICOM", "NIfTI", "Dictionaries"])
 
 using DICOM, NIfTI, Dictionaries
 
@@ -19,59 +19,59 @@ then it will load the image and return a MedImage object with the image data and
 
 function load_image(path::String)::MedImage
 
-    #check if the path is a folder or a file
-    properties = ["pixel_array","direction","spacing","orientation","origin","date_of_saving","patient_id"]
-    values = Vector{Any}()
+  #check if the path is a folder or a file
+  properties = ["pixel_array", "direction", "spacing", "orientation", "origin", "date_of_saving", "patient_id"]
+  values = Vector{Any}()
 
 
-    if isdir(path)
-        #load the dicom folder
-      
-      #due to added confusion only the first file is being accessed from the loaded dicom directory
-      list_of_dicom_files = readdir(path)
-      dicom_data_array = DICOM.dcmdir_parse(path)
-      dicom_data_file = dicom_data_array[1] #only accessing the first file in the dicom folder for now 
-      #tags refernce from below
-      #https://github.com/JuliaHealth/DICOM.jl/blob/master/src/dcm_dict.jl
-      #apparently a lot of the tags within in the above are not within the dicom file dict
-      #more accurate one 
-      #https://towardsdatascience.com/dealing-with-dicom-using-imageio-python-package-117f1212ab82
-      append!(values,[
-        dicom_data_file[tag"PizelData"], #pixel data 
-        dicom_data_file[tag"ImageOrientationPatient"], #direction
-        dicom_data_file[tag"PixelSpacing"], #spacing
-        dicom_data_file[tag"ImagePositionPatient"], #orientation, and origin similar?
-        dicom_data_file[tag"ImagePositionPatient"], #origin
-        joinpath(path,list_of_dicom_files[1]),
-        dicom_data_file[tag"PatientID"]
-      ])
+  if isdir(path)
+    #load the dicom folder
 
-      """
-      list_of_dicom_files = readdir(path)  
-      #assuming that dicom folder contains unzrchived data
-      if len(list_of_dicom_files) != 0 && (list_of_dicom_files[1] !== "." || list_of_dicom_files[1] !== "..")
-      file = open(joinpath(path,list_of_dicom_files[1]),"r")
-      dicom_file = DICOM>dcm_parse(file)
-      end
-      """
-      
-    
-    else
-        #dealing and handling nifti files 
-        #load the nifti file
-      nifti_image = NIfTI.niread(path)
-      header = nifti_image.header 
-      
-      append!(values,[nifti_image.raw,
-                  (header.srow_x[1:3], header.srow_y[1:3], header.srow_z[1:3]), 
-                  header.pixdim[2:4],
-                  (header.srow_x,header.srow_y,header.srow_z),
-                  (header.qoffset_x, header.qoffset_y, header_qoffset_z),
-                  path,
-                  ""])
+    #due to added confusion only the first file is being accessed from the loaded dicom directory
+    list_of_dicom_files = readdir(path)
+    dicom_data_array = DICOM.dcmdir_parse(path)
+    dicom_data_file = dicom_data_array[1] #only accessing the first file in the dicom folder for now 
+    #tags refernce from below
+    #https://github.com/JuliaHealth/DICOM.jl/blob/master/src/dcm_dict.jl
+    #apparently a lot of the tags within in the above are not within the dicom file dict
+    #more accurate one 
+    #https://towardsdatascience.com/dealing-with-dicom-using-imageio-python-package-117f1212ab82
+    append!(values, [
+      dicom_data_file[tag"PizelData"], #pixel data 
+      dicom_data_file[tag"ImageOrientationPatient"], #direction
+      dicom_data_file[tag"PixelSpacing"], #spacing
+      dicom_data_file[tag"ImagePositionPatient"], #orientation, and origin similar?
+      dicom_data_file[tag"ImagePositionPatient"], #origin
+      joinpath(path, list_of_dicom_files[1]),
+      dicom_data_file[tag"PatientID"]
+    ])
+
+    """
+    list_of_dicom_files = readdir(path)  
+    #assuming that dicom folder contains unzrchived data
+    if len(list_of_dicom_files) != 0 && (list_of_dicom_files[1] !== "." || list_of_dicom_files[1] !== "..")
+    file = open(joinpath(path,list_of_dicom_files[1]),"r")
+    dicom_file = DICOM>dcm_parse(file)
     end
-    MedImage_struct_attributes = Dictionaries.Dictionary(properties,values)
-    return MedImage(MedImage_struct_attributes)
+    """
+
+
+  else
+    #dealing and handling nifti files 
+    #load the nifti file
+    nifti_image = NIfTI.niread(path)
+    header = nifti_image.header
+
+    append!(values, [nifti_image.raw,
+      (header.srow_x[1:3], header.srow_y[1:3], header.srow_z[1:3]),
+      header.pixdim[2:4],
+      (header.srow_x, header.srow_y, header.srow_z),
+      (header.qoffset_x, header.qoffset_y, header_qoffset_z),
+      path,
+      ""])
+  end
+  MedImage_struct_attributes = Dictionaries.Dictionary(properties, values)
+  return MedImage(MedImage_struct_attributes)
 
 end#load_image
 
@@ -81,7 +81,7 @@ given a MedImage object and a path to a nifti file save the MedImage object into
 """
 function save_image(im::MedImage, path::String)
 
-  
+
 end#save_image
 
 

--- a/MedImage3D/src/Load_and_save.jl
+++ b/MedImage3D/src/Load_and_save.jl
@@ -16,35 +16,82 @@ first it needs to recognise weather it works with a dicom folder or a nifti file
 then it will load the image and return a MedImage object with the image data and the metadata
 """
 
+function handle_single_medimage_object_from_dicom(dicom_data_array, sub_values, path, list_of_dicom_files)
+  # we are retreiving data from the first dicom files, since all the other files have same Series ID, so spatial meta data wont change
+  append!(sub_values, [
+    dicom_data_array[1][tag"PixelData"],
+    dicom_data_array[1][tag"ImageOrientationPatient"],
+    dicom_data_array[1][tag"PixelSpacing"],
+    dicom_data_array[1][tag"ImagePositionPatient"],
+    dicom_data_array[1][tag"ImagePositionPatient"],
+    joinpath(path, list_of_dicom_files[1]),
+    dicom_data_array[1][tag"PatientID"]
+  ])
+end
 
-function load_image(path::String)::MedImage
+function handle_multiple_medimage_objects_from_dicom(dicom_data_array,values,sub_values,path,list_of_dicom_files,dicom_tag_series_instance_uid_tuples, pixel_data_array)
+  list_of_unique_series_id_tag = Set(tuple[3] for tuple in dicom_tag_series_instance_uid_tuples) 
+  for series_id in list_of_unique_series_id_tag
+    selected_tuple = ()
+    for tuple in dicom_tag_series_instance_uid_tuples
+      if tuple[3] == series_id
+        selected_tuple = tuple
+      end
+    end
+    append!(sub_values,[
+      pixel_data_array,
+      dicom_data_array[selected_tuple[1]][tag"ImageOrientationPatient"],
+      dicom_data_array[selected_tuple[1]][tag"PixelSpacing"],
+      dicom_data_array[selected_tuple[1]][tag"ImagePositionPatient"],
+      dicom_data_array[selected_tuple[1]][tag"ImagePositionPatient"],
+      joinpath(path,list_of_dicom_files[selected_tuple[1]]),
+      dicom_data_array[selected_tuple[1]][tag"PatientID"]
+    ]) 
+    push!(values,sub_values)
+  end
+end
+
+
+
+
+function load_image(path::String)::Union{MedImage, Vector{MedImage}}
 
   #check if the path is a folder or a file
   properties = ["pixel_array", "direction", "spacing", "orientation", "origin", "date_of_saving", "patient_id"]
   values = Vector{Any}()
-
+  sub_values = Vector{Any}()
 
   if isdir(path)
     #load the dicom folder
 
-    #due to added confusion only the first file is being accessed from the loaded dicom directory
+    #dicom directory consists up of multiple dicom files with same metadata , but different pixel array data since each image is a 2d layer, whereas a nifti image  deals with 3d data
     list_of_dicom_files = readdir(path)
     dicom_data_array = DICOM.dcmdir_parse(path)
-    dicom_data_file = dicom_data_array[1] #only accessing the first file in the dicom folder for now 
+    #only accessing the first file in the dicom folder for now 
+    dicom_tag_series_instance_uid_tuples = []
+    list_of_unique_dicom_series_id_tag = []
+    dicom_pixel_data_array = [] #contains array of 2d pixel data array
+    dicom_data_file = dicom_data_array[1]
+
+    for (index, dicom_data_file) in enumerate(dicom_data_array)
+      push!(dicom_tag_series_instance_uid_tuples, (index, dicom_data_file[tag"SeriesNumber"], dicom_data_file[tag"SeriesInstanceUID"]))
+      push!(dicom_pixel_data_array, dicom_data_file[tag"PixelData"])
+    end
+
+
+    if length(list_of_unique_dicom_series_id_tag) == 1
+      handle_single_medimage_object_from_dicom(dicom_data_array, sub_values, path, list_of_dicom_files)
+      push!(values,sub_values)
+    else
+      handle_multiple_medimage_objects_from_dicom(dicom_data_array,values,sub_values,path,list_of_dicom_files,dicom_tag_series_instance_uid_tuples,dicom_pixel_data_array)
+    end
     #tags refernce from below
     #https://github.com/JuliaHealth/DICOM.jl/blob/master/src/dcm_dict.jl
     #apparently a lot of the tags within in the above are not within the dicom file dict
     #more accurate one 
     #https://towardsdatascience.com/dealing-with-dicom-using-imageio-python-package-117f1212ab82
-    append!(values, [
-      dicom_data_file[tag"PizelData"], #pixel data 
-      dicom_data_file[tag"ImageOrientationPatient"], #direction
-      dicom_data_file[tag"PixelSpacing"], #spacing
-      dicom_data_file[tag"ImagePositionPatient"], #orientation, and origin similar?
-      dicom_data_file[tag"ImagePositionPatient"], #origin
-      joinpath(path, list_of_dicom_files[1]),
-      dicom_data_file[tag"PatientID"]
-    ])
+
+
 
     """
     list_of_dicom_files = readdir(path)  
@@ -62,27 +109,37 @@ function load_image(path::String)::MedImage
     nifti_image = NIfTI.niread(path)
     header = nifti_image.header
 
-    append!(values, [nifti_image.raw,
+    
+    append!(sub_values, [nifti_image.raw,
       (header.srow_x[1:3], header.srow_y[1:3], header.srow_z[1:3]),
       header.pixdim[2:4],
       (header.srow_x, header.srow_y, header.srow_z),
-      (header.qoffset_x, header.qoffset_y, header_qoffset_z),
+      (header.qoffset_x, header.qoffset_y, header.qoffset_z),
       path,
       ""])
+    push!(values,sub_values)
   end
-  MedImage_struct_attributes = Dictionaries.Dictionary(properties, values)
+  
+  if length(values) == 1
+    MedImage_struct_attributes = Dictionaries.Dictionary(properties, values[1])
   return MedImage(MedImage_struct_attributes)
-
+  else
+    medimage_object_array = []
+    for value_array in values
+      MedImage_struct_attributes = Dictionaries.Dictionary(properties,value_array)
+      push!(medimage_object_array, MedImage(MedImage_struct_attributes))
+    end
+    return medimage_object_array
+  end
 end#load_image
 
 """
 given a MedImage object and a path to a nifti file save the MedImage object into a nifti file
 
 """
+
 function save_image(im::MedImage, path::String)
-
-
+  
 end#save_image
-
 
 

--- a/MedImage3D/src/MedImage_data_struct.jl
+++ b/MedImage3D/src/MedImage_data_struct.jl
@@ -1,12 +1,19 @@
+using Pkg
+Pkg.add(["Dictionaries"])
+using Dictionaries
+
+
+
+
+
+
+
 """
 Here we define necessary data structures for the project.
 Main data structure is a MedImage object which is a 3D image with some metadata.
 
 !!!! Currently implemented as Struct but will be better to use as metadata arrays
 """
-using Pkg
-Pkg.add(["Dictionaries"])
-using Dictionaries
 
 #following struct can be expanded with all the relevant meta data mentioned within the readme.md of MedImage.jl
 struct MedImage

--- a/MedImage3D/src/MedImage_data_struct.jl
+++ b/MedImage3D/src/MedImage_data_struct.jl
@@ -4,8 +4,9 @@ Main data structure is a MedImage object which is a 3D image with some metadata.
 
 !!!! Currently implemented as Struct but will be better to use as metadata arrays
 """
-
-
+using Pkg
+Pkg.add(["Dictionaries"])
+using Dictionaries
 
 #following struct can be expanded with all the relevant meta data mentioned within the readme.md of MedImage.jl
 struct MedImage
@@ -20,7 +21,7 @@ end
 
 
 #constructor function for MedImage
-function MedImage(MedImage_struct_attributes::Dict{String,Any})
+function MedImage(MedImage_struct_attributes::Dictionaries.Dictionary{String,Any})
     return MedImage(
         get(MedImage_struct_attributes,"pixel_array",[]),
         get(MedImage_struct_attributes,"direction",[]),

--- a/MedImage3D/test_data/experiment_dicom.jl
+++ b/MedImage3D/test_data/experiment_dicom.jl
@@ -1,0 +1,43 @@
+using Pkg
+Pkg.add(["DICOM", "NIfTI"])
+using DICOM
+using NIfTI
+
+
+path_to_dicom_directory = "/home/hurtbadly/Desktop/julia_stuff/MedImage.jl/MedImage3D/test_data/ScalarVolume_0"
+dicom_data_array = DICOM.dcmdir_parse(path_to_dicom_directory)
+
+
+#println(dicom_data_array[1][tag"PixelData"])
+#println(dicom_data[1][tag"SeriesId"])
+#println("here starts the second file")
+#println(dicom_data_array[2][tag"PixelData"])
+#
+#
+#unique indedx, and series_instanceUID so we know exactly how many medimage objects to create since change in that will denote a change within the spatial meta data 
+##one way of doing that
+
+dicom_files_tuples_series_id = []
+list_of_unique_series_id = []
+dicom_pixel_data_array = []
+
+for (index, dicom_data_file) in enumerate(dicom_data_array)
+  push!(dicom_files_tuples_series_id, (index, dicom_data_file[tag"SeriesInstanceUID"]))
+  push!(dicom_pixel_data_array, dicom_data_file[tag"PixelData"])
+end
+
+
+println(list_of_unique_series_id)
+
+
+
+
+
+
+
+
+
+#list_of_unique_dicom_files = [(index,series_id) for (index,series_id) in list_of_unique_dicom_files if series_id in list_of_unique_dicom_files_set]
+#println(list_of_unique_dicom_files_set)
+#
+


### PR DESCRIPTION
Added a lot of changes, within Load_and_save.jl
--created a function for returning an array of MedImage objects. if the the "Series Instance UID" tag of individual dicom files is not similar.
-- added type for save_and_load function to either return an array of MedImage objects, or a single MedImage object.
(using union)